### PR TITLE
[fix]meeting version 제거, alram map 제거

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -172,7 +172,6 @@ model Meeting {
   id         Int      @id @default(autoincrement())
   contractId Int
   date       DateTime
-  version    Int      @default(1)
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
@@ -190,8 +189,8 @@ enum ContractStatus {
 }
 
 enum AlarmTime {
-  DAY_BEFORE_9AM @map("dayBefore9am")
-  ON_DAY_9AM     @map("onDay9am")
+  DAY_BEFORE_9AM 
+  ON_DAY_9AM    
 }
 
 model ContractDocument {


### PR DESCRIPTION
말씀드렸던 Meeting vesion 제거했습니다
alram은 저희 서비스 정책인거 같아서 enum이 맞는거 같기도 하고, 변환 로직 다 만들어두신거 같아
도메인 enum이랑 DB에 다르게 저장되게 만드는 map만 지워봤습니다