### PR TITLE
[fix] 목록 조회 기능 수정

### DIFF
--- a/src/1_inbound/middlewares/file-upload.middleware.ts
+++ b/src/1_inbound/middlewares/file-upload.middleware.ts
@@ -36,7 +36,6 @@ export class FileUploadMiddleware {
     } catch (err) {
       next(err);
     }
-<<<<<<< Updated upstream:src/1_inbound/middlewares/file-upload.middleware.ts
   }
 
   imageUploadHandler = (
@@ -52,7 +51,4 @@ export class FileUploadMiddleware {
       next(err);
     }
   }
-=======
-  };
->>>>>>> Stashed changes:src/1_inbound/middlewares/multer.middleware.ts
 }

--- a/src/1_inbound/requests/contract-schema.request.ts
+++ b/src/1_inbound/requests/contract-schema.request.ts
@@ -78,6 +78,26 @@ export const updateContractStatusReqSchema = z.object({
 
 export const updateContractReqSchema = z.object({
   body: z.object({
+    status: z
+      .string()
+      .transform((val) => {
+        const upper = val.toUpperCase();
+        if (CONTRACT_STATUS_KEYS.includes(upper as any)) {
+          return upper;
+        }
+        const lower = val.toLowerCase().replace(/[_-]/g, "");
+        const statusMapping: Record<string, string> = {
+            carinspection: "CAR_INSPECTION",
+            pricenegotiation: "PRICE_NEGOTIATION",
+            contractdraft: "CONTRACT_DRAFT",
+            contractsuccessful: "CONTRACT_SUCCESSFUL",
+            contractfailed: "CONTRACT_FAILED",
+        };
+        return statusMapping[lower] || val;
+      })
+      .pipe(z.enum(CONTRACT_STATUS_KEYS))
+      .optional(),
+
     resolutionDate: z.string().regex(ISO_DATETIME_REGEX).nullable().optional(),
 
     contractPrice: z.number().int().min(0).optional(),

--- a/src/3_outbound/repos/contract.repo.ts
+++ b/src/3_outbound/repos/contract.repo.ts
@@ -109,10 +109,14 @@ export class ContractRepo extends BaseRepo implements IContractRepo {
   async update(id: number, entity: ContractEntity) {
     try {
       const { contract, meeting } = ContractMapper.toUpdateData(entity);
+
+      const prismaStatus = this._toPrismaStatus(contract.status);
+
       const record = await this._prisma.contract.update({
         where: { id, version: contract.version },
         data: {
           ...contract,
+          status: prismaStatus,
           version: { increment: 1 },
           meeting: meeting,
         } as any,


### PR DESCRIPTION
## 수정 사항

- 계약 목록 조회중, 차량 목록 조회 기능 수정 완료

---

## 수정한 곳

- 다음과 같은 파일을 수정했습니다.
    - contract-schema.request.ts
    - contract.service.ts
    - contract.repo.ts

---

## contract-schema.request.ts

- updateContractReqSchema 메소드 내 다음 항목 추가
```
    status: z
      .string()
      .transform((val) => {
        const upper = val.toUpperCase();
        if (CONTRACT_STATUS_KEYS.includes(upper as any)) {
          return upper;
        }
        const lower = val.toLowerCase().replace(/[_-]/g, "");
        const statusMapping: Record<string, string> = {
            carinspection: "CAR_INSPECTION",
            pricenegotiation: "PRICE_NEGOTIATION",
            contractdraft: "CONTRACT_DRAFT",
            contractsuccessful: "CONTRACT_SUCCESSFUL",
            contractfailed: "CONTRACT_FAILED",
        };
        return statusMapping[lower] || val;
      })
      .pipe(z.enum(CONTRACT_STATUS_KEYS))
      .optional(),
```

---

## contract.service.ts

- 다음 메소드를 수정함 (수정한 양이 많음으로 파일 참고)
    - updateContractStatus
    - updateContractDetail
    - createContract
    - getContractCars

---

## contract.repo.ts

- update 메소드 내 다음 항목 추가 및 수정
```
      const prismaStatus = this._toPrismaStatus(contract.status);

      const record = await this._prisma.contract.update({
        where: { id, version: contract.version },
        data: {
          ...contract,
          status: prismaStatus,
          version: { increment: 1 },
          meeting: meeting,
        } as any,
        include: this._includeOption,
      });
```