### PR TITLE
김경연/contract [fix] 고객 유니크 제약 조건 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,6 +99,7 @@ model Customer {
   @@index([name])
   @@index([email])
   @@index([name, email])
+  @@unique([email, companyId])
 }
 
 enum CarManufacturer {

--- a/src/3_outbound/repos/customer.repo.ts
+++ b/src/3_outbound/repos/customer.repo.ts
@@ -60,6 +60,14 @@ export class CustomerRepo extends BaseRepo implements ICustomerRepo {
       const newRecord = await this._prisma.customer.create({ data });
       return CustomerMapper.fromPersistence(newRecord);
     } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError) {
+        if (err.code === "P2002") {
+          throw new TechnicalException({
+            type: TechnicalExceptionType.UNIQUE_VIOLATION_EMAIL,
+            error: err,
+          });
+        }
+      }
       throw err;
     }
   }

--- a/src/4_shared/exceptions/business.exceptions/exception-info.ts
+++ b/src/4_shared/exceptions/business.exceptions/exception-info.ts
@@ -66,6 +66,7 @@ export enum BusinessExceptionType {
   CONTRACT_NOT_EXIST,
   CONTRACT_STATUS_CHANGED,
   CONTRACT_DATA_CHANGED,
+  ALREADY_EXIST_EAMIL,
 }
 
 export const BusinessExceptionTable: Record<
@@ -323,6 +324,10 @@ export const BusinessExceptionTable: Record<
   [BusinessExceptionType.CUSTOMER_DATA_ARLEADY_DELETE]: {
     statusCode: 409,
     message: "요청하신 고객 정보가 삭제되었습니다.",
+  },
+  [BusinessExceptionType.ALREADY_EXIST_EAMIL]: {
+    statusCode: 409,
+    message: "이미 존재하는 이메일입니다.",
   },
 
   // 기타


### PR DESCRIPTION
프론트엔드 예시 페이지에서 완전히 같은 정보로 등록해도 문제없이 등록되어서 일단은 제약조건 없이 구현했었는데, 
아무래도 이상해서 프론트엔드 연결 전에 제약조건 추가하여 수정합니다
email, companyid만 unique로 묶었습니다

DB충돌, 런타임 오류 없이 테스트 잘 되는 거 확인했습니다
migrate 해주셔요!